### PR TITLE
[#2] Add create_robotdocs task

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,14 @@
 CHANGES
 =======
 
+1.2
+---
+
+ - Add task for creating Robot Framework documentation only
+
 1.1
 ---
 
  - Add initial content
+
+

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
                       'robotframework',
                       'virtualenvrunner',
                       'virtualenv==16.3.0',
-                      'crl.repo',
                       'configparser'],
     long_description=read('README.rst'),
     license='BSD 3-Clause',

--- a/src/crl/devutils/_version.py
+++ b/src/crl/devutils/_version.py
@@ -1,5 +1,5 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
-VERSION = '1.1'
+VERSION = '1.2'
 GITHASH = ''
 
 

--- a/src/crl/devutils/tasks.py
+++ b/src/crl/devutils/tasks.py
@@ -406,12 +406,11 @@ def create_docs(robotdocs_root_folders='robotdocs', verbose=False):
     }
 
     Robotdocsconf.py's output_file will be the name of the generated
-    'sphinxdocs/.........rst' file. Good practice to name it so that library's
-    identification is easy. If output_file is missing then robotdocs.rst will
-    be the file name.
-    Robotdocsconf.py's module_name will be written to rst file header. Header
-    text will be: 'Robot Framework Test Libraries' if the module name is
-    missing.
+    'sphinxdocs/.........rst' file. A good practice is to name it so that
+    library's identification is easy. If output_file is missing then
+    robotdocs.rst will be the file name.  Robotdocsconf.py's module_name will
+    be written to rst file header. Header text will be: 'Robot Framework Test
+    Libraries' if the module name is missing.
 
     Sphinx documentation is generated according to 'sphinxdocs/conf.py'.
 
@@ -426,6 +425,64 @@ def create_docs(robotdocs_root_folders='robotdocs', verbose=False):
     """
     create_doccreator(verbose=verbose,
                       robotdocs_root_folders=robotdocs_root_folders).create()
+
+
+@task
+def create_robotdocs(robotdocs_root_folders='robotdocs', verbose=False):
+    """ Create only Robot Framework ReST documentation.
+
+    If 'robotdocsconf.py' exists in root folders then Robot
+    Framework test libraries and resource files documentation
+    is generated and integrated with Sphinx documentation.
+    'robotdocsconf.py' is searched from robotdocs_root_folders
+     recursively.
+
+    Example 1 'robotdocsconf.py' for python library documentation:
+
+    module_name = "RunnerExecutor Libraries"
+    output_file = "RunnerExecutor.rst"
+
+    robotdocs = {
+    'RunnerExecutor.remoterunnerexecutor.RemoteRunnerExecutor': {
+        'args': ['None', 'None', 'False'],
+        'docformat': 'robot',
+        'synopsis': ('Command executor in the remote target shell.')},
+    'RunnerExecutor.remoterunnerexecutor.SftpTransfer': {
+        'args': ['False'],
+        'docformat': 'robot',
+        'synopsis': ('Command executor in the remote target shell.')}
+
+    Example 2 'robotdocsconf.py' for robot resource file documentation:
+    module_name = "Deployment Helpers"
+    output_file = "Framework_deployment.rst"
+
+    robotdocs = {
+    'resources/framework/deployment/_deployment_helper.robot': {
+        'docformat': 'robot'
+        }
+    }
+
+    Robotdocsconf.py's output_file will be the name of the generated
+    'sphinxdocs/.........rst' file. A good practice is to name it so that
+    library's identification is easy. If output_file is missing then
+    robotdocs.rst will be the file name.  Robotdocsconf.py's module_name will
+    be written to rst file header. Header text will be: 'Robot Framework Test
+    Libraries' if the module name is missing.
+
+    Sphinx documentation is generated according to 'sphinxdocs/conf.py'.
+
+    Args:
+        robotdocs_root_folders: folders list with relative or
+        absolute path separated by ':',
+        robotdocsconf.py is searched from these root folders recursively
+        verbose: Display task execution in more detail.
+
+    Example:
+        crl create_robotdocs -r library_root_folder1:library_root_folder2 -v
+    """
+    create_doccreator(
+        verbose=verbose,
+        robotdocs_root_folders=robotdocs_root_folders).create_robotdocs()
 
 
 @contextmanager

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -14,7 +14,8 @@ from crl.devutils.tasks import (
     tag_setup_version,
     create_index,
     delete_index,
-    create_docs)
+    create_docs,
+    create_robotdocs)
 from crl.devutils.runner import Failure, Result
 from crl.devutils.versionhandler import (
     VersionHandler,
@@ -390,6 +391,16 @@ def test_create_docs(mock_create_doccreator, verbose):
         verbose=verbose,
         robotdocs_root_folders='robotdocs')
     assert mock_create_doccreator.handler.create.call_count == 1
+
+
+@pytest.mark.parametrize('verbose', [True, False])
+def test_create_robotdocs(mock_create_doccreator, verbose):
+    create_robotdocs(verbose=verbose, robotdocs_root_folders='robotdocs')
+
+    mock_create_doccreator.create.assert_called_once_with(
+        verbose=verbose,
+        robotdocs_root_folders='robotdocs')
+    assert mock_create_doccreator.handler.create_robotdocs.call_count == 1
 
 
 @pytest.mark.parametrize('verbose', [True, False])


### PR DESCRIPTION
Creation of the Robot Framework documentation should be possible
without creating Sphinx documentation.