### PR TITLE
[#4] Correct error in mock_exec_file_with_exec

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 CHANGES
 =======
 
+1.2.1
+-----
+
+ - Correct syntax error in mock_exec_file_with_exec
+
 1.2
 ---
 

--- a/src/crl/devutils/_version.py
+++ b/src/crl/devutils/_version.py
@@ -1,5 +1,5 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
-VERSION = '1.2'
+VERSION = '1.2.1'
 GITHASH = ''
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -99,15 +99,14 @@ class MockExecFileWithMockFile(object):
         self._request.addfinalizer(self.mock_file.stop)
 
     def _setup_execfile_mock(self):
-
-        def mock_execfile_with_exec(filename, namespace):
-            exec(self.mock_file.content, namespace)
-
         epatch = mock.patch(
             'crl.devutils.versionhandler.utils.execfile',
-            mock_execfile_with_exec)
+            self._mock_execfile_with_exec)
         epatch.start()
         self._request.addfinalizer(epatch.stop)
+
+    def _mock_execfile_with_exec(self, filename, namespace):
+        exec(self.mock_file.content, namespace)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Travis-CI fails with SyntaxError because the test function
mock_exec_file_exec is a nested function containing exec call.