### PR TITLE
Add link to documentation to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,15 @@
 Guide for developing Common Robot Libraries (CRL) via crl.devutils
 ##################################################################
 
+
+Documentation
+=============
+
+Documentation for crl.devutils can be found from `Read The Docs`_.
+
+.. _Read The Docs: http://crl-devutils.readthedocs.io/
+
+
 Setup
 =====
 


### PR DESCRIPTION
Link is needed from GitHub and PyPI crl.devutils pages which
show only README.