### PR TITLE
Require check-manifest==0.41 to avoid devpi upload error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@
 CHANGES
 =======
 
+1.2.5
+-----
+
+- Require check-manifest==0.41 to avoid 'devpi upload' error caused
+  by backwards incompatible change
+
 1.2.4
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     author_email='petri.huovinen@nokia.com',
     description='Common Robot Libraries development and CI tools',
     install_requires=['invoke==0.12.2',
+                      'check-manifest==0.41',
                       'devpi-client==4.1.0',
                       'detox==0.15',
                       'tox==3.4.0',

--- a/src/crl/devutils/_version.py
+++ b/src/crl/devutils/_version.py
@@ -1,5 +1,5 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
-VERSION = '1.2.4'
+VERSION = '1.2.5'
 GITHASH = ''
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands = pylint {posargs: --reports=n  --rcfile={toxinidir}/.pylintrc \
 [testenv:pylint3]
 basepython = python3.7
 deps =
-    pylint
+    pylint == 2.5
     {[base3]deps}
 commands = {[testenv:pylint]commands}
 


### PR DESCRIPTION
'devpi upload' fails with TypeError in check_manifest.detect_vcs()

Reason is that we require devpi-client==4.1.0 but do not pin down
check-manifest, which changed detect_vcs function in backwards
incompatible manner in version 0.42.

Fixes issue #18