### PR TITLE
Use Python 3.10 in CI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
-.. Copyright (C) 2019, Nokia
+.. Copyright (C) 2019-2024, Nokia
 
 CHANGES
 =======
+
+1.3.1
+-----
+
+- Support running 'crl test' in Python 3.10 environment
 
 1.3.0
 -----

--- a/ci/tox.ini
+++ b/ci/tox.ini
@@ -1,8 +1,11 @@
-# Copyright (C) 2019, Nokia
+# Copyright (C) 2019-2024, Nokia
 
 [tox]
 skipsdist = True
 
+
+[testenv]
+setenv=PIP_TIMEOUT=60
 
 [testenv:publish]
 changedir={env:WORKDIR:}

--- a/robotdocs/robotdocsconf.py
+++ b/robotdocs/robotdocsconf.py
@@ -1,0 +1,10 @@
+__copyright__ = 'Copyright (C) 2024, Nokia'
+
+
+robotdocs = {
+    'crl.devutils.tmpdir.TmpDir': {
+        'docformat': 'robot',
+        'args': [],
+        'synopsis': 'TmpDir class for creating temporary directories',
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
                       'six',
                       'rstcheck',
                       'setuptools==69.2.0;python_version>="3.10"',
-                      'sphinx',
+                      'sphinx<7.0',
                       'Jinja2==3.0.3;python_version>"3.0"',
                       'robotframework',
                       'virtualenvrunner',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-__copyright__ = 'Copyright (C) 2019-2022, Nokia'
+__copyright__ = 'Copyright (C) 2019-2024, Nokia'
 
 VERSIONFILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -43,6 +43,7 @@ setup(
                       'future',
                       'six',
                       'rstcheck',
+                      'setuptools==69.2.0;python_version>="3.10"',
                       'sphinx',
                       'Jinja2==3.0.3;python_version>"3.0"',
                       'robotframework',

--- a/sphinxdocs/conf.py
+++ b/sphinxdocs/conf.py
@@ -21,7 +21,7 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 
-__copyright__ = 'Copyright (C) 2019, Nokia'
+__copyright__ = 'Copyright (C) 2019-2024, Nokia'
 
 
 from crl.devutils._version import get_version
@@ -73,12 +73,12 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = []
+exclude_patterns = ['robotdocs.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -105,6 +105,7 @@ html_theme_options = {'page_width': '90%'}
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ['_static']
 
+html_extra_path = ['../robotdocs']
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/src/crl/devutils/_version.py
+++ b/src/crl/devutils/_version.py
@@ -1,5 +1,5 @@
-__copyright__ = 'Copyright (C) 2019, Nokia'
-VERSION = '1.3.0'
+__copyright__ = 'Copyright (C) 2019-2024, Nokia'
+VERSION = '1.3.1'
 GITHASH = ''
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands = pylint {posargs: --reports=n  --rcfile={toxinidir}/.pylintrc \
                            {toxinidir}/src/crl {toxinidir}/tests}
 
 [testenv:pylint3]
-basepython = python3.7
+basepython = python3.10
 deps =
     pylint == 2.5
     {[base3]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright (C) 2019, Nokia
+# Copyright (C) 2019-2024, Nokia
 [tox]
 envlist = py{27,36,37,38,39,310}, docs, pylint, pylint3
 
@@ -25,6 +25,7 @@ deps =
 [testenv]
 setenv =
     COVERAGE_FILE = .coverage{envname}
+    PIP_TIMEOUT = 60
 passenv = COVERAGE_FILE
 changedir = {envtmpdir}
 commands =
@@ -73,6 +74,7 @@ basepython=python3.7
 changedir={toxinidir}
 deps={[testenv:docs]deps}
 setenv=
+    {[testenv]setenv}
     TOX_PARALLEL_NO_SPINNER=1
 commands=
     crl test --no-virtualenv --toxargs "--parallel auto" {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps =
 commands = {[testenv:pylint]commands}
 
 [testenv:docs]
-basepython=python3.7
+basepython=python3.10
 changedir={toxinidir}
 deps =
     sphinx-invoke
@@ -70,7 +70,7 @@ commands =
     crl create_docs -v
 
 [testenv:test]
-basepython=python3.7
+basepython=python3.10
 changedir={toxinidir}
 deps={[testenv:docs]deps}
 setenv=


### PR DESCRIPTION
Python 3.7 is retired and not available in Fedora 40, which is used as Jenkins agent in CI pipelines.