### PR TITLE
Build and upload py3 wheel package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ coverage.xml
 junit.xml
 src/crl_devutils.egg-info/
 .pytest_cache/*
+robotdocs/crl.devutils.tmpdir.TmpDir.html
+sphinxdocs/robotdocs.rst

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@
 CHANGES
 =======
 
+1.4.0
+-----
+
+- Support selecting release files for which 'crl test' is running tests via new CLI
+  argument '--select'. This makes possible testing of non-universal wheels besides
+  source distributions or selecting only one of them.
+
 1.3.1
 -----
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,10 @@
-# Copyright (C) 2019, Nokia
+# Copyright (C) 2019-2024, Nokia
 
 [build_sphinx]
 source-dir = sphinxdocs
+
+[devpi:upload]
+formats = sdist,bdist_wheel
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
                       'future',
                       'six',
                       'rstcheck',
-                      'setuptools==69.2.0;python_version>="3.10"',
+                      'setuptools==68.2.2;python_version>="3.10"',
                       'sphinx<7.0',
                       'Jinja2==3.0.3;python_version>"3.0"',
                       'robotframework',

--- a/src/crl/devutils/_tmpindex.py
+++ b/src/crl/devutils/_tmpindex.py
@@ -6,7 +6,7 @@ from crl.devutils.doccreator import DocCreator
 from crl.devutils.devpiindex import DevpiIndex
 
 
-__copyright__ = 'Copyright (C) 2019, Nokia'
+__copyright__ = 'Copyright (C) 2019-2024, Nokia'
 
 
 class _TmpIndex(DevpiIndex):
@@ -48,18 +48,25 @@ class _TmpIndex(DevpiIndex):
         if self._default_cleanup:
             self.delete_index()
 
-    def test(self, toxargs=None):
+    def test(self, toxargs=None, select=None):
         self._upload()
-        self.run('devpi test {spec}{clientarg}{toxargs}'.format(
+        self.run('devpi test {spec}{clientarg}{toxargs}{select}'.format(
             spec=self.spec,
             clientarg=self.clientarg,
-            toxargs=self._get_formatted_toxargs(toxargs)))
+            toxargs=self._get_formatted_toxargs(toxargs),
+            select=self._get_formatted_select(select)))
 
     @staticmethod
     def _get_formatted_toxargs(toxargs):
         if toxargs is None:
             return ''
         return ' --tox-args "{toxargs}"'.format(toxargs=toxargs)
+
+    @staticmethod
+    def _get_formatted_select(select):
+        if select is None:
+            return ''
+        return ' --select "{select}"'.format(select=select)
 
     def _upload(self):
         self.run('devpi upload{clientarg}'.format(

--- a/src/crl/devutils/_version.py
+++ b/src/crl/devutils/_version.py
@@ -1,5 +1,5 @@
 __copyright__ = 'Copyright (C) 2019-2024, Nokia'
-VERSION = '1.3.1'
+VERSION = '1.4.0'
 GITHASH = ''
 
 

--- a/src/crl/devutils/devpihandler.py
+++ b/src/crl/devutils/devpihandler.py
@@ -8,7 +8,7 @@ from crl.devutils._tmpindex import _TmpIndex
 from crl.devutils.utils import get_randomstring
 
 
-__copyright__ = 'Copyright (C) 2019, Nokia'
+__copyright__ = 'Copyright (C) 2019-2024, Nokia'
 
 
 class MalformedURL(Exception):
@@ -107,7 +107,7 @@ class DevpiHandler(object):
         with self._session():
             self._publish(index)
 
-    def test(self, test_index=None, toxargs=None):
+    def test(self, test_index=None, toxargs=None, select=None):
         """
         Test and upload results and docs to the given index.
         If no index is specified, uses a temporary index.
@@ -115,9 +115,10 @@ class DevpiHandler(object):
         Args:
           test_index: Index name to use for testing, specified as NAME.
           toxargs: extra command line arguments for tox.
+          select: Selector for the tests to run.
         """
         with self._session():
-            self._test_via_tmpindex(test_index, toxargs)
+            self._test_via_tmpindex(test_index, toxargs, select)
 
     def create_index(self, name, baseindex, otherbase=None,
                      credentials_file=None):
@@ -293,7 +294,7 @@ class DevpiHandler(object):
         index.use_index()
         index.push(pkgspec, short_index_name)
 
-    def _test_via_tmpindex(self, index, toxargs):
+    def _test_via_tmpindex(self, index, toxargs, select):
         with _TmpIndex(run=self.run,
                        packagehandler=self.packagehandler,
                        baseindex=self.userindex,
@@ -301,4 +302,4 @@ class DevpiHandler(object):
                        index_name=index,
                        username=self.username,
                        clientarg=self._clientarg) as tmpindex:
-            tmpindex.test(toxargs=toxargs)
+            tmpindex.test(toxargs=toxargs, select=select)

--- a/src/crl/devutils/packagehandler.py
+++ b/src/crl/devutils/packagehandler.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from crl.devutils.tmpdir import TmpDir
 
 
-__copyright__ = 'Copyright (C) 2019, Nokia'
+__copyright__ = 'Copyright (C) 2019-2024, Nokia'
 
 
 class MismatchOfTagAndVersionfileVersion(Exception):
@@ -152,7 +152,8 @@ class PackageHandler(object):
              test_index=None,
              credentials_file=None,
              save_tests_to=None,
-             toxargs=None):
+             toxargs=None,
+             select=None):
         """
         Runs tests and uploads the results and docs to a given index.
         If no index is given, a temporary index which is created for
@@ -168,6 +169,9 @@ class PackageHandler(object):
             generated during testing to this path.
           toxargs: Extra command line arguments passsed to tox, e.g.
             "--parallel all"
+          select: Selector for release files to be tested. This is
+            a regular expression passed to 'devpi test' as '--seclect'
+            argument, for example "(-py3-none-any.whl|.tar.gz)"
 
         Raises:
           ChangeFileVersionCheckFailed: Change file version doesn't
@@ -179,7 +183,7 @@ class PackageHandler(object):
             if credentials_file:
                 self.devpihandler.set_credentials_file(credentials_file)
             with self._prepared_package():
-                self.devpihandler.test(test_index, toxargs)
+                self.devpihandler.test(test_index, toxargs, select)
 
     def publish(self,
                 srcindex,

--- a/src/crl/devutils/tasks.py
+++ b/src/crl/devutils/tasks.py
@@ -34,7 +34,7 @@ from crl.devutils.githandler import UncleanGitRepository
 from crl.devutils.doccreator import FailedToCreateDocs
 
 
-__copyright__ = 'Copyright (C) 2019, Nokia'
+__copyright__ = 'Copyright (C) 2019-2024, Nokia'
 
 MODULEDIR = os.path.dirname(os.path.abspath(__file__))
 SETUP_TEMPLATE = """
@@ -308,10 +308,10 @@ def delete_index(index, credentials_file=None, verbose=False):
 
 
 @task
-def test(baseindex, testindex=None, credentials_file=None,
+def test(baseindex, testindex=None, credentials_file=None,  # pylint: disable=too-many-arguments
          save_tests_to=None, virtualenv=True,
          pathtoversionfile=None, verbose=False,
-         toxargs=None):
+         toxargs=None, select=None):
     """ Uploads contents of current workspace to devpi and runs tox tests.
 
     Args:
@@ -331,6 +331,9 @@ def test(baseindex, testindex=None, credentials_file=None,
         verbose: Display task execution in more detail.
         toxargs: Extra command line arguments for tox. e.g.
                  --toxargs="--parallel all"
+        select: Selector for release files to be tested. This is
+                a regular expression passed to 'devpi test' as '--select'
+                argument, for example "(-py3-none-any.whl|.tar.gz)"
     """
     kwargs = {} if virtualenv else {'novirtualenv': True}
     ph = create_packagehandler(verbose=verbose,
@@ -339,7 +342,8 @@ def test(baseindex, testindex=None, credentials_file=None,
     ph.test(base_index=baseindex, test_index=testindex,
             credentials_file=credentials_file,
             save_tests_to=save_tests_to,
-            toxargs=toxargs)
+            toxargs=toxargs,
+            select=select)
 
 
 @task

--- a/tests/test_devpihandler.py
+++ b/tests/test_devpihandler.py
@@ -16,7 +16,7 @@ from .fixtures import (  # pylint: disable=unused-import
 from .mockfile import MockFile
 
 
-__copyright__ = 'Copyright (C) 2019, Nokia'
+__copyright__ = 'Copyright (C) 2019-2024, Nokia'
 
 
 @pytest.fixture(scope='function')
@@ -134,7 +134,7 @@ def test_test(devpihandler,
         clientarg=' --clientdir {expected_clientdir}'.format(
             expected_clientdir=randomtmpdir))
     mock_tmpindex.handle.test.assert_called_once_with(
-        toxargs=None)
+        toxargs=None, select=None)
 
 
 @pytest.mark.parametrize('index,expected_url', [

--- a/tests/test_packagehandler.py
+++ b/tests/test_packagehandler.py
@@ -28,7 +28,7 @@ from .fixtures import (  # pylint: disable=unused-import
     create_mpatch)
 
 
-__copyright__ = 'Copyright (C) 2019, Nokia'
+__copyright__ = 'Copyright (C) 2019-2024, Nokia'
 
 
 @pytest.fixture(scope='function')
@@ -196,7 +196,7 @@ def test_test_with_index_name(packagehandler,
                               mock_verify_clean,
                               test_index):
     packagehandler.test(base_index='index', test_index=test_index)
-    packagehandler.devpihandler.test.assert_called_once_with(test_index, None)
+    packagehandler.devpihandler.test.assert_called_once_with(test_index, None, None)
     assert packagehandler.devpihandler.test.call_count == 1
     assert mock_prepare_package.call_count == 1
     assert mock_verify_clean.call_count == 0

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -43,7 +43,7 @@ from .fixtures import (  # pylint: disable=unused-import
     mock_devpihandler)
 
 
-__copyright__ = 'Copyright (C) 2019, Nokia'
+__copyright__ = 'Copyright (C) 2019-2024, Nokia'
 
 
 MockHandlerFactory = namedtuple('MockHandlerFactory', [
@@ -208,21 +208,22 @@ def test_set_version(mock_create_packagehandler,
     assert err == ''
 
 
-@pytest.mark.parametrize('testindex,save_tests_to,pathtoversionfile,toxargs',
-                         [(None, None, PathToVersionFile(), None),
+@pytest.mark.parametrize('testindex,save_tests_to,pathtoversionfile,toxargs,select',
+                         [(None, None, PathToVersionFile(), None, None),
                           ('test', 'save_tests_to',
-                           PathToVersionFile('path'), '--parallel all')])
+                           PathToVersionFile('path'), '--parallel all', '-py3-none-any.whl')])
 def test_test(mock_create_packagehandler,
               testindex,
               save_tests_to,
               pathtoversionfile,
-              toxargs):
+              toxargs,
+              select):
     test(baseindex='index', testindex=testindex, credentials_file='creds',
-         save_tests_to=save_tests_to, toxargs=toxargs,
+         save_tests_to=save_tests_to, toxargs=toxargs, select=select,
          **pathtoversionfile.kwargs)
     mock_create_packagehandler.handler.test.assert_called_once_with(
         base_index='index', test_index=testindex, credentials_file='creds',
-        save_tests_to=save_tests_to, toxargs=toxargs)
+        save_tests_to=save_tests_to, toxargs=toxargs, select=select)
 
 
 def test_test_without_virtualenv(mock_create_packagehandler):

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,9 @@ changedir={toxinidir}
 filterwarnings =
     ignore:cannot collect .test. because it is not a function
 
+[flake8]
+max-line-length = 100
+
 [testenv:pylint]
 basepython = python2.7
 deps =
@@ -77,4 +80,4 @@ setenv=
     {[testenv]setenv}
     TOX_PARALLEL_NO_SPINNER=1
 commands=
-    crl test --no-virtualenv --toxargs "--parallel auto" {posargs}
+    crl test --no-virtualenv --toxargs "--parallel auto" --select "(-py2.py3-none-any.whl|.tar.gz)" {posargs}


### PR DESCRIPTION
Support selecting release files for which 'crl test' is running tests via new 'crl test' argument '--select'.
Also change setup.cfg to build py3 wheel and upload both sdist and bdist_wheel to PyPI index.